### PR TITLE
Api and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+### The final branch / stretch goals were built entirely with copilot prompts, summarized below:
+
+#### API
+
+- Add a namespaced controller and API endpoints (routes, etc.) for fetching collections of levels by arbitrary date_scopes, following the existing patterns.
+- Update line 6 of the new controller to use the existing from_date_range scope.
+- Write tests for this new endpoint (I got RSpec tests here, so followed by:)
+- This codebase doesn't use rspec; all other tests are in minitest. Follow this established pattern.
+- The levels fixtures referenced in the new test don't exist. Use the existing fixtures, and adjust tested dates to suit those existing fixtures.
+- `.expect` won't raise an ActionController::ParameterMissing; it 400's instead. Adjust the test to reflect this behavior.
+- Make start_date and end_date into datetime objects (beginning of day, and end of day, respectively).
+- Because we're usng beginning_of_day and end_of_day in the scope, the tested dates on line 19 are not returning an empty array, and the test fails. Adjust the tested date range only, do not apply beginning_of_day or end_of_day within the test file.
+- Update the API controller and the test to also scope the returned levels by member. If new fixtures need to be created to test this new functionality, do so.
+

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ Things you may want to cover:
 - Because we're usng beginning_of_day and end_of_day in the scope, the tested dates on line 19 are not returning an empty array, and the test fails. Adjust the tested date range only, do not apply beginning_of_day or end_of_day within the test file.
 - Update the API controller and the test to also scope the returned levels by member. If new fixtures need to be created to test this new functionality, do so.
 
+#### Caching
+
+- Implement Rails caching on MemberDashboard results, keyed on member.id and level.level_type. Expire the cache at the beginning of each day. (keyed instead on `date_scope`, so:)
+- Rather than date_scope as a cache_key, key the cache on member.id and level_type

--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ Things you may want to cover:
 
 - Implement Rails caching on MemberDashboard results, keyed on member.id and level.level_type. Expire the cache at the beginning of each day. (keyed instead on `date_scope`, so:)
 - Rather than date_scope as a cache_key, key the cache on member.id and level_type
+
+Upon review, all 3 are appropriate:
+
+- Include the date_scope in the cache_key

--- a/app/controllers/api/v1/levels_controller.rb
+++ b/app/controllers/api/v1/levels_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V1
+    class LevelsController < ApplicationController
+      def index
+        levels = Level.where(member_id: member_id).from_date_range(start_date, end_date)
+        render json: levels
+      end
+
+      private
+
+      def member_id
+        params.expect(:member_id)
+      end
+
+      def start_date
+        DateTime.parse(params.expect(:start_date)).beginning_of_day
+      end
+
+      def end_date
+        DateTime.parse(params.expect(:end_date)).end_of_day
+      end
+    end
+  end
+end

--- a/app/services/member_dashboard.rb
+++ b/app/services/member_dashboard.rb
@@ -18,29 +18,39 @@ class MemberDashboard
   end
 
   def data(date_scope:)
-    scoped_levels = @member.scoped_levels_for(level_type: @level_type, date_scope: date_scope)
-    return {} if scoped_levels.blank?
+    Rails.cache.fetch(cache_key, expires_in: time_until_end_of_day) do
+      scoped_levels = @member.scoped_levels_for(level_type: @level_type, date_scope: date_scope)
+      return {} if scoped_levels.blank?
 
-    average = scoped_levels.average(:value).round(2)
-    time_above_threshold_percentage = scoped_levels.above_threshold(180).count / scoped_levels.count.to_f * 100
-    time_below_threshold_percentage = scoped_levels.below_threshold(70).count / scoped_levels.count.to_f * 100
-    time_in_range_percentage = scoped_levels.in_range(70, 180).count / scoped_levels.count.to_f * 100
-    change_from_prior_period_percentage = calculate_change_from_prior_period(scoped_levels: scoped_levels, date_scope: date_scope)
+      average = scoped_levels.average(:value).round(2)
+      time_above_threshold_percentage = scoped_levels.above_threshold(180).count / scoped_levels.count.to_f * 100
+      time_below_threshold_percentage = scoped_levels.below_threshold(70).count / scoped_levels.count.to_f * 100
+      time_in_range_percentage = scoped_levels.in_range(70, 180).count / scoped_levels.count.to_f * 100
+      change_from_prior_period_percentage = calculate_change_from_prior_period(scoped_levels: scoped_levels, date_scope: date_scope)
 
-    {
-      member: @member,
-      level_type: @level_type,
-      unit:,
-      date_scope:,
-      average:,
-      time_above_threshold_percentage:,
-      time_below_threshold_percentage:,
-      time_in_range_percentage:,
-      change_from_prior_period_percentage:
-    }
+      {
+        member: @member,
+        level_type: @level_type,
+        unit:,
+        date_scope:,
+        average:,
+        time_above_threshold_percentage:,
+        time_below_threshold_percentage:,
+        time_in_range_percentage:,
+        change_from_prior_period_percentage:
+      }
+    end
   end
 
   private
+
+  def cache_key
+    "member_dashboard/#{@member.id}/#{@level_type}"
+  end
+
+  def time_until_end_of_day
+    (Time.current.end_of_day - Time.current).to_i
+  end
 
   def calculate_change_from_prior_period(scoped_levels:, date_scope:)
     case date_scope

--- a/app/services/member_dashboard.rb
+++ b/app/services/member_dashboard.rb
@@ -18,7 +18,7 @@ class MemberDashboard
   end
 
   def data(date_scope:)
-    Rails.cache.fetch(cache_key, expires_in: time_until_end_of_day) do
+    Rails.cache.fetch(cache_key(date_scope), expires_in: time_until_end_of_day) do
       scoped_levels = @member.scoped_levels_for(level_type: @level_type, date_scope: date_scope)
       return {} if scoped_levels.blank?
 
@@ -44,8 +44,8 @@ class MemberDashboard
 
   private
 
-  def cache_key
-    "member_dashboard/#{@member.id}/#{@level_type}"
+  def cache_key(date_scope)
+    "member_dashboard/#{@member.id}/#{@level_type}/#{date_scope}"
   end
 
   def time_until_end_of_day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,12 @@ Rails.application.routes.draw do
     get "levels/:level_type/table_data", to: "member_levels#table_data", as: :levels_table_data
   end
 
+  namespace :api do
+    namespace :v1 do
+      resources :levels, only: [ :index ]
+    end
+  end
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/api/v1/levels_controller_test.rb
+++ b/test/controllers/api/v1/levels_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Api::V1::LevelsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @member = members(:one)
+    @other_member = members(:two)
+    @level1 = levels(:near_one)   # tested_at: 1 day ago, member_id: 1
+    @level2 = levels(:near_two)   # tested_at: 2 days ago, member_id: 1
+    @level3 = levels(:near_three) # tested_at: 3 days ago, member_id: 1
+    @other_member_level = levels(:other_member_level) # tested_at: 1 day ago, member_id: 2
+  end
+
+  test "should return levels within the specified date range for a specific member" do
+    get api_v1_levels_url, params: { member_id: @member.id, start_date: 3.days.ago.to_date, end_date: 1.day.ago.to_date }
+    assert_response :success
+    response_data = JSON.parse(@response.body)
+    assert_equal 3, response_data.size
+  end
+
+  test "should return an empty array when no levels match the date range for a specific member" do
+    get api_v1_levels_url, params: { member_id: @member.id, start_date: 12.days.ago.to_date, end_date: 11.days.ago.to_date }
+    assert_response :success
+    response_data = JSON.parse(@response.body)
+    assert_empty response_data
+  end
+
+  test "should not return levels for other members" do
+    get api_v1_levels_url, params: { member_id: @member.id, start_date: 1.day.ago.to_date, end_date: 1.day.ago.to_date }
+    assert_response :success
+    response_data = JSON.parse(@response.body)
+    assert_not_includes response_data.map { |level| level["id"] }, @other_member_level.id
+  end
+
+  test "should return 400 Bad Request when parameters are missing" do
+    get api_v1_levels_url, params: { start_date: 3.days.ago.to_date }
+    assert_response :bad_request
+  end
+end

--- a/test/fixtures/levels.yml
+++ b/test/fixtures/levels.yml
@@ -51,3 +51,11 @@ oldest_one:
   tested_at: <%= 2.months.ago %>
   tz_offset: "-4:00"
   unit: "mg/dL"
+
+other_member_level:
+  member_id: 2
+  level_type: "continuous_glucose_monitoring"
+  value: 150
+  tested_at: <%= 1.day.ago %>
+  tz_offset: "-4:00"
+  unit: "mg/dL"

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -9,3 +9,9 @@ one:
   first_name: "John"
   last_name: "Doe"
   email: "john_doe@omada.com"
+
+two:
+  id: 2
+  first_name: "Jane"
+  last_name: "Smith"
+  email: "jane_smith@omada.com"


### PR DESCRIPTION
## Objective

Per the provided brief: 

> Bonus:
> - Implement an API that can return metrics for a given member and time frame.
> - Consider caching strategies for performance enhancement.

## Acceptance Criteria

API - Standard rails-namespaced (api/v1) for levels, accepting a member_id and date_scope
Caching - Standard rails cache access for MemberDashboard results, expiring daily.

## Implementation Notes

Copilot didn't seem fully up to date on some newer features from Rails 8 (didn't want to use `.expect` without specific prompting, and even flagged it on review, for example). 

Because of this, I didn't lean too heavily on the whole-cloth code production via prompts in the earlier branches of this project. I still incorporated assisted auto-completes that provided useful code, such intuiting the functionality I wanted from Level's various scopes based on the name. 

For the two listed stretch goals (caching and an API endpoint to scope on member / arbitrary date_scope), I wanted to apply this prompt-coding more intentionally. With the foundational elements of the codebase in place, this went much more smoothly, and I didn't end up writing a line of this PR "by hand". See README for a summary of prompts used.